### PR TITLE
ghq/github.com/kattsun44 直下の config 読み込みパスを変更

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -13,7 +13,7 @@
 	aa = add -A
 	ps = push origin
 	pl = pull origin
-	
+
 [http]
 	postBuffer = 524288000
 [credential]
@@ -22,3 +22,6 @@
 	quotepath = false
 [push]
 	default = current
+[init]
+	defaultBranch = main
+

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,6 +1,9 @@
 [include]
 	path = ~/.gitconfig.local
 
+[includeIf "gitdir:~/ghq/github.com/kattsun44/"]
+	path = ~/.gitconfig_sub
+
 [alias]
 	st = status
 	b = branch


### PR DESCRIPTION
refs:
- [複数のGitHubアカウントを使い分けたい時の設定方法とTips](https://zenn.dev/taichifukumoto/articles/how-to-use-multiple-github-accounts)
- [git initのデフォルトブランチ名をmasterからmainに変更する #Git - Qiita](https://qiita.com/tkhslab/items/ecfa1800e0d65ee46fb8)